### PR TITLE
Split Energy and Environment, change Civil Liberties to Social Justice

### DIFF
--- a/txlege84/topics/management/commands/bootstraptopics.py
+++ b/txlege84/topics/management/commands/bootstraptopics.py
@@ -14,7 +14,6 @@ class Command(BaseCommand):
 
         topics = [
             u'Budget & Taxes',
-            u'Business & Technology',
             u'Criminal Justice',
             u'Energy',
             u'Environment',


### PR DESCRIPTION
Per Emily's request.

Energy and Environment are two separate topics now. Civil Liberties became Social Justice. Business & Technology is gone.
