### PR TITLE
fixed bill table size on subject pages

### DIFF
--- a/txlege84/templates/pages/subject.html
+++ b/txlege84/templates/pages/subject.html
@@ -2,11 +2,11 @@
 
 {% block content %}
 
-  <div class="body-main">
+  <div>
     <h2>{{ object.name }}</h2>
   </div>
 
-<section class="body-main">
+<section>
   <table>
     <thead>
       <tr>


### PR DESCRIPTION
The bill table was weird because it had an old class around it. Better now.
