### PR TITLE
All interactions with Issues use get_absolute_url now

### DIFF
--- a/txlege84/templates/components/landing-modules/top-issues.html
+++ b/txlege84/templates/components/landing-modules/top-issues.html
@@ -7,7 +7,7 @@
     <ul>
       {% for top_issue in top_issues %}
       <li>
-        <p><a href="{% url 'issue-detail' top_issue.issue.topic.slug top_issue.issue.slug %}">{{ top_issue.issue.name }}</a></p>
+        <p><a href="{{ top_issue.get_absolute_url }}">{{ top_issue.issue.name }}</a></p>
       </li>
       {% endfor %}
     </ul>

--- a/txlege84/templates/components/page-headers/hot-list-header.html
+++ b/txlege84/templates/components/page-headers/hot-list-header.html
@@ -17,7 +17,7 @@
   <nav class="full-hot-list">
     <ul>
     {% for issue in object.issues.all %}
-      <li><a href="{% url 'issue-detail' object.slug issue.slug %}">{{ issue.name | truncatewords:5 }}</a></li>
+      <li><a href="{{ issue.get_absolute_url }}">{{ issue.name | truncatewords:5 }}</a></li>
     {% endfor %}
     </ul>
   </nav>

--- a/txlege84/templates/components/page-headers/hot-list-issue-header.html
+++ b/txlege84/templates/components/page-headers/hot-list-issue-header.html
@@ -14,7 +14,7 @@
   <nav class="full-hot-list">
     <ul>
     {% for issue in object.topic.issues.all %}
-      <li><a href="{% url 'issue-detail' object.slug issue.slug %}">{{ issue.name | truncatewords:5 }}</a></li>
+      <li><a href="{{ issue.get_absolute_url }}">{{ issue.name | truncatewords:5 }}</a></li>
     {% endfor %}
     </ul>
   </nav>

--- a/txlege84/templates/pages/issue.html
+++ b/txlege84/templates/pages/issue.html
@@ -13,7 +13,7 @@
   <div class="issue-box">
     <header>
       <h3 id="{{ issue.slug }}">
-        <a href="{% url 'issue-detail' object.slug issue.slug %}">{{ issue.name }}</a>
+        <a href="{{ issue.get_absolute_url }}">{{ issue.name }}</a>
       </h3>
 <!--       <h4><i class="fa fa-bell"></i> <a href="">Alert me</a> when this issue is updated.</h4> -->
       <h4>Tell your friends:

--- a/txlege84/templates/pages/topic-list-landing.html
+++ b/txlege84/templates/pages/topic-list-landing.html
@@ -35,7 +35,7 @@
     <div class="issue-list">
       <ul>
       {% for issue in topic.issues.all %}
-        <li><a href="{% url 'issue-detail' topic.slug issue.slug %}">{{ issue.name }}</a></li>
+        <li><a href="{{ issue.get_absolute_url }}">{{ issue.name }}</a></li>
       {% endfor %}
       </ul>
     </div>

--- a/txlege84/templates/pages/topic-list.html
+++ b/txlege84/templates/pages/topic-list.html
@@ -16,7 +16,7 @@
   <div class="issue">
     <header>
       <h3 id="{{ issue.slug }}">
-        <a href="{% url 'issue-detail' object.slug issue.slug %}">{{ issue.name }}</a>
+        <a href="{{ issue.get_absolute_url }}">{{ issue.name }}</a>
       </h3>
       <h4>Updated: {{ issue.modified_date|date:"N j, Y" }}</h4>
     </header>


### PR DESCRIPTION
About to do this for _all_ models that lead to pages, but here's a pull just for interactions with the `Issue` model.

Fixes #71 
