### PR TITLE
hides table headers if no bills in category

### DIFF
--- a/txlege84/templates/pages/subject.html
+++ b/txlege84/templates/pages/subject.html
@@ -15,6 +15,7 @@
 {% block content %}
 
 <section>
+{% if object.bills.first != null %}
   <table class="bill-table">
     <thead>
       <tr>
@@ -33,6 +34,9 @@
     {% endfor %}
     </tbody>
   </table>
+{% else %}
+<p>No bills have been filed under this category yet.</p>
+{% endif %}
 </section>
 
 {% endblock %}


### PR DESCRIPTION
instead there's a nice message telling them to move along.

An example of this is the 'drugs' category.
