### PR TITLE
fix rotating ad script

### DIFF
--- a/txlege84/static/scripts/main.js
+++ b/txlege84/static/scripts/main.js
@@ -107,8 +107,8 @@
   // Rotating Ad
   var roofline = {
     interval: 15 * 1000,
-    desktopAds: $('#rotating_ad').children('.mobile-hide').find('.rotating-ad'),
-    mobileAds: $('#rotating_ad').children('.desktop-hide').find('.rotating-ad'),
+    desktopAds: $('.rotating-ad-container').children('.mobile-hide').find('.rotating-ad'),
+    mobileAds: $('.rotating-ad-container').children('.desktop-hide').find('.rotating-ad'),
     init: function(){
       if (roofline.desktopAds.length <= 1 && roofline.mobileAds.length <= 1) {
         return false;

--- a/txlege84/templates/includes/rotating_ad.html
+++ b/txlege84/templates/includes/rotating_ad.html
@@ -1,4 +1,4 @@
-<div id="rotating_ad" class="rotating-ad-container" style="position:relative;">
+<div id="rotating_adA" class="rotating-ad-container" style="position:relative;">
 
   <div class="mobile-hide large_ad_container">
     <div class="ad-container rotating-ad" id="div-gpt-ad-1406570316312-4">

--- a/txlege84/templates/includes/rotating_ad_mobile.html
+++ b/txlege84/templates/includes/rotating_ad_mobile.html
@@ -1,4 +1,4 @@
-<div id="rotating_ad" class="rotating-ad-container" style="position:relative;">
+<div id="rotating_adB" class="rotating-ad-container" style="position:relative;">
   <div class="desktop-hide">
     <div class="ad-container rotating-ad" id="div-gpt-ad-1406570316312-8">
       <script>


### PR DESCRIPTION
Script was hitting two objects with the same ID. Changed it to find the class of the ad-container for both mobile, desktop views.
