### PR TITLE
add back staging target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,27 @@ prep_for_development:
 pull:
 	git pull
 
+master:
+	git checkout master
+
+staging:
+	git checkout staging
+
 docker/build:
 	docker build --tag=${IMAGE} .
 
-docker/prod: pull docker/build
+docker/prod: pull master docker/build
 	-docker stop ${APP} && docker rm ${APP}
 	docker run --name=${APP} \
+		--hostname=${APP}-prod \
+		--detach=true \
+		--publish=80:8000 \
+		--env-file=env ${IMAGE}
+
+docker/staging: pull staging docker/build
+	-docker stop ${APP} && docker rm ${APP}
+	docker run --name=${APP} \
+		--hostname=${APP}-staging \
 		--detach=true \
 		--publish=80:8000 \
 		--env-file=env ${IMAGE}


### PR DESCRIPTION
#### What's this PR do?
- adds Makefile targets to:
  - checkout master
  - checkout staging
  - execute the docker image against staging
  - adds a `hostname` parameter to the docker invocation
#### Why are we doing this? How does it help us?
- the old `docker/staging` target was lost in git weirdness; this adds it back
- the new `--hostname` parameter should make it easier to distinguish what's going on in Sentry, NewRelic and any future logging service
#### How should this be manually tested?
- not easy to test because doing so will check out a branch that doesn't have this change
#### What are the relevant tickets?

N/A
#### Next steps?
- Merge to master.
- Merge master to `v2.0`
#### Smells?
