### PR TITLE
Do not reload entire page with style changes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,7 +92,8 @@ gulp.task('styles', function() {
     }))
     .pipe(gulpIf('*.css', csso()))
     .pipe(gulp.dest('txlege84/static/css'))
-    .pipe(size({title: 'styles'}));
+    .pipe(size({title: 'styles'}))
+    .pipe(gulpIf('*.css', reload({stream: true})));
 });
 
 gulp.task('clean', function() {
@@ -110,7 +111,7 @@ gulp.task('serve', ['styles', 'scripts'], function() {
   });
 
   gulp.watch(['txlege84/templates/**/*.html'], reload);
-  gulp.watch(['txlege84/static/scss/**/*.scss'], ['styles', reload]);
+  gulp.watch(['txlege84/static/scss/**/*.scss'], ['styles']);
   gulp.watch(['txlege84/static/scripts/**/*.js'], ['jshint', 'scripts', reload]);
 });
 


### PR DESCRIPTION
CSS changes shouldn't make the browse reload. But I was dumb and set up `browser-sync` wrong. This fixes that. You'll be much happier. I promise.
