### PR TITLE
V2.0 Story pointers sort on pub_date instead of order

### DIFF
--- a/txlege84/topics/admin.py
+++ b/txlege84/topics/admin.py
@@ -26,10 +26,12 @@ class IssueTextAdmin(admin.ModelAdmin):
         js = ('ckeditor/ckeditor.js',)
 
 
-class StoryPointerInline(SortableInlineAdminMixin, admin.TabularInline):
+class StoryPointerInline(admin.TabularInline):
     model = StoryPointer
 
-    extra = 0
+    exclude = ('order',)
+
+    extra = 1
 
 
 class IssueTextInline(admin.TabularInline):

--- a/txlege84/topics/models.py
+++ b/txlege84/topics/models.py
@@ -94,11 +94,11 @@ class StoryPointer(models.Model):
     headline = models.CharField(max_length=200)
     url = models.URLField()
     pub_date = models.DateField()
-    order = models.PositiveIntegerField(default=0)
+    order = models.PositiveIntegerField(default=0)  # no longer used!
     issue = models.ForeignKey(Issue, related_name='stories')
 
     class Meta:
-        ordering = ('order',)
+        ordering = ('-pub_date',)
 
     def __unicode__(self):
         return self.headline


### PR DESCRIPTION
Story timelines now sort on `pub_date` instead of a reporter/editor determined `order` field.
