### PR TITLE
Queryset should re-evaluate on each load

### DIFF
--- a/txlege84/core/views.py
+++ b/txlege84/core/views.py
@@ -7,6 +7,8 @@ from topics.models import FeaturedTopic, Topic
 
 
 class LandingView(FeaturedTopicMixin, ConveneTimeMixin, ListView):
-    # only returns the one not considered a featured topic
-    queryset = Topic.objects.exclude(id=FeaturedTopic.objects.first().topic.id)
     template_name = 'landing.html'
+
+    def get_queryset(self):
+        # only returns the one not considered a featured topic
+        return Topic.objects.exclude(id=FeaturedTopic.objects.first().topic.id)


### PR DESCRIPTION
I had the filter hooked up with the view's `queryset` property. But that only evaluates on first load of the app, which means if someone changes the `FeaturedTopic`, that won't be reflected until the app restarts.

Moving this to `get_queryset()` means it'll get regenerated on each page load. Sure there's a smell there, but it fixes it for now.

Source: http://stackoverflow.com/a/19707855/4512285
