### PR TITLE
removed space and target blank from directory and ethics explorer links

### DIFF
--- a/txlege84/templates/pages/legislator.html
+++ b/txlege84/templates/pages/legislator.html
@@ -14,7 +14,7 @@
       <header class="lawmaker-name page-header">
         <h2>{{ object.chamber.short_name }} {{ object.full_name }}</h2>
         <p class="sub-text">District {{ object.district }} (<span class="{{ object.party.name|lower }}">{{ object.party.short_name }}</span> - {{ object.tribune_city }})</p>
-        <p class="sub-text"><a href="{{ object.tribune_directory_url }} target=_blank">View in Directory</a> | <a href="{{ object.tribune_ethics_url }} target=_blank">View in Ethics Explorer</a></p>
+        <p class="sub-text"><a href="{{ object.tribune_directory_url }}">View in Directory</a> | <a href="{{ object.tribune_ethics_url }}">View in Ethics Explorer</a></p>
       </header>
   </div>
     <section class="share-page">


### PR DESCRIPTION
Directory links work yay.

Did we want to get rid of all instances of target="_blank" aside form social?
