### PR TITLE
Add admin interface for changing stream options

### DIFF
--- a/txlege84/bills/migrations/0006_auto_20150506_1458.py
+++ b/txlege84/bills/migrations/0006_auto_20150506_1458.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bills', '0005_auto_20150323_1715'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='bill',
+            options={'ordering': ('chamber__name', 'bill_type', 'bill_number')},
+        ),
+    ]

--- a/txlege84/core/admin.py
+++ b/txlege84/core/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 
-from core.models import ConveneTime, Staff
+from core.models import ConveneTime, Staff, Stream
 
 
 class EmployeeInline(admin.StackedInline):
@@ -17,3 +17,4 @@ class UserAdmin(UserAdmin):
 admin.site.unregister(User)
 admin.site.register(User, UserAdmin)
 admin.site.register(ConveneTime)
+admin.site.register(Stream)

--- a/txlege84/core/migrations/0006_stream.py
+++ b/txlege84/core/migrations/0006_stream.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('legislators', '0007_auto_20150311_1607'),
+        ('core', '0005_convenetime_active'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Stream',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('granicus_subdomain', models.CharField(help_text=b'Granicus subdomain for stream', max_length=20)),
+                ('camera_id', models.IntegerField(help_text=b'Identifier for direct camera stream')),
+                ('direct_event_feed', models.BooleanField(default=False, help_text=b'Use an event feed instead of a camera feed')),
+                ('feed_id', models.IntegerField(help_text=b'Feed identifier for direct embed', null=True, blank=True)),
+                ('event_id', models.IntegerField(help_text=b'Event identifier for direct embed', null=True, blank=True)),
+                ('chamber', models.OneToOneField(related_name='stream_for', to='legislators.Chamber', help_text=b'Chamber viewable in stream')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/txlege84/core/migrations/0007_create_default_streams.py
+++ b/txlege84/core/migrations/0007_create_default_streams.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def add_default_streams(apps, schema_editor):
+    Chamber = apps.get_model('legislators', 'Chamber')
+    Stream = apps.get_model('core', 'Stream')
+
+    Stream.objects.create(
+        chamber=Chamber.objects.get(name='Texas House'),
+        granicus_subdomain='tlchouse',
+        camera_id=3,
+        direct_event_feed=False,
+    )
+
+    Stream.objects.create(
+        chamber=Chamber.objects.get(name='Texas Senate'),
+        granicus_subdomain='tlcsenate',
+        camera_id=8,
+        direct_event_feed=False,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0006_stream'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_default_streams),
+    ]

--- a/txlege84/core/models.py
+++ b/txlege84/core/models.py
@@ -25,3 +25,26 @@ class ConveneTime(models.Model):
         if (self.time < timezone.now()) and self.active:
             return True
         return False
+
+
+class Stream(models.Model):
+    chamber = models.OneToOneField(
+        Chamber,
+        help_text='Chamber viewable in stream',
+        related_name='stream_for')
+    granicus_subdomain = models.CharField(
+        help_text='Granicus subdomain for stream', max_length=20)
+    camera_id = models.IntegerField(
+        help_text='Identifier for direct camera stream')
+    direct_event_feed = models.BooleanField(
+        help_text='Use an event feed instead of a camera feed',
+        default=False)
+    feed_id = models.IntegerField(
+        help_text='Feed identifier for direct embed',
+        null=True, blank=True)
+    event_id = models.IntegerField(
+        help_text='Event identifier for direct embed',
+        null=True, blank=True)
+
+    def __unicode__(self):
+        return u'Stream for {}'.format(self.chamber)

--- a/txlege84/static/scripts/main.js
+++ b/txlege84/static/scripts/main.js
@@ -1,4 +1,4 @@
-/* global Bloodhound, FastClick */
+/* global Bloodhound, FastClick, streamMapping */
 
 $(document).ready(function() {
   'use strict';
@@ -85,38 +85,27 @@ $(document).ready(function() {
   });
 
   // LegeStream
-  var streamMapping = {
-    'house-stream': {
-      subdomain: 'tlchouse',
-      cameraId: '3'
-    },
-    'senate-stream': {
-      subdomain: 'tlcsenate',
-      cameraId: '8',
-      feedId: '5',
-      eventId: '929'
-    }
-  };
+  if (typeof streamMapping !== 'undefined') {
+    var streamLoader = function(id, width, height) {
+      var stream = streamMapping[id];
+      var iframeHeight = height + 30;
 
-  var $streamPlaceholder = $('.stream-placeholder');
+      if (stream.feedId) {
+        return '<iframe scrolling="no" style="border:0" width="' + width + '" height="' + iframeHeight + '" id="GranicusFlashPlayerFrame" src="http://' + stream.subdomain + '.granicus.com/mediaplayer.php?feed_id=' + stream.feedId + '&event_id=' + stream.eventId + '&embed=1&player_width=' + width + '&player_height=' + height + '"></iframe>';
+      } else {
+        return '<iframe scrolling="no" style="border:0" width="' + width + '" height="' + iframeHeight + '" id="GranicusFlashPlayerFrame" src="http://' + stream.subdomain + '.granicus.com/mediaplayer.php?camera_id=' + stream.cameraId + '&embed=1&player_width=' + width + '&player_height=' + height + '"></iframe>';
+      }
+    };
 
-  $streamPlaceholder.one('click', function() {
-    var $this = $(this);
-    $this.addClass('stream-activated');
-    var width = $this.parent().width();
-    var height = width * 0.5625;
-    $this.find('.stream-prompt').replaceWith(streamLoader(this.id, width, height));
-  });
+    var $streamPlaceholder = $('.stream-placeholder');
 
-  function streamLoader(id, width, height) {
-    var stream = streamMapping[id];
-    var iframeHeight = height + 30;
-
-    if (stream.feedId) {
-      return '<iframe scrolling="no" style="border:0" width="' + width + '" height="' + iframeHeight + '" id="GranicusFlashPlayerFrame" src="http://' + stream.subdomain + '.granicus.com/mediaplayer.php?feed_id=' + stream.feedId + '&event_id=' + stream.eventId + '&embed=1&player_width=' + width + '&player_height=' + height + '"></iframe>';
-    } else {
-      return '<iframe scrolling="no" style="border:0" width="' + width + '" height="' + iframeHeight + '" id="GranicusFlashPlayerFrame" src="http://' + stream.subdomain + '.granicus.com/mediaplayer.php?camera_id=' + stream.cameraId + '&embed=1&player_width=' + width + '&player_height=' + height + '"></iframe>';
-    }
+    $streamPlaceholder.one('click', function() {
+      var $this = $(this);
+      $this.addClass('stream-activated');
+      var width = $this.parent().width();
+      var height = width * 0.5625;
+      $this.find('.stream-prompt').replaceWith(streamLoader(this.id, width, height));
+    });
   }
 
   // Rotating Ad

--- a/txlege84/templates/pages/legestream.html
+++ b/txlege84/templates/pages/legestream.html
@@ -52,3 +52,21 @@
     </article>
   </section>
 {% endblock %}
+
+{% block extra_head %}
+{{ block.super }}
+<script>
+var streamMapping = {
+  'house-stream': {
+    subdomain: '{{ house.stream_for.granicus_subdomain }}',
+  {% if house.stream_for.direct_event_feed %}feedId: '{{ house.stream_for.feed_id }}', eventId: '{{ house.stream_for.event_id }}'
+  {% else %}cameraId: '{{ house.stream_for.camera_id }}'{% endif %}
+  },
+  'senate-stream': {
+    subdomain: '{{ senate.stream_for.granicus_subdomain }}',
+  {% if senate.stream_for.direct_event_feed %}feedId: '{{ senate.stream_for.feed_id }}', eventId: '{{ senate.stream_for.event_id }}'
+  {% else %}cameraId: '{{ senate.stream_for.camera_id }}'{% endif %}
+  }
+};
+</script>
+{% endblock %}


### PR DESCRIPTION
Wednesday afternoon we had an issue with the Senate stream's channel tanking. While it's relatively easy to do a code switch to address that, it'd be much better to do it via the admin.

This adds the capacity to change the channels set for the House and Senate streams, or, if necessary, switch them over to an event feed as a hotfix.

(As a random side note – this also enables these feeds to show **any** channel or event that's running, including committee hearings.)
