### PR TITLE
Order fix

### DIFF
--- a/txlege84/bills/management/commands/loadbills.py
+++ b/txlege84/bills/management/commands/loadbills.py
@@ -196,8 +196,6 @@ class Command(BaseCommand):
                 openstates_id=member['leg_id']
             )
 
-            print(legislator)
-
             Sponsorship.objects.update_or_create(
                 legislator=legislator,
                 bill=bill,

--- a/txlege84/bills/migrations/0008_auto_20150706_1823.py
+++ b/txlege84/bills/migrations/0008_auto_20150706_1823.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bills', '0007_bill_vetoed'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='sponsorship',
+            options={'ordering': ['ordering']},
+        ),
+        migrations.AddField(
+            model_name='sponsorship',
+            name='ordering',
+            field=models.PositiveIntegerField(default=0),
+            preserve_default=True,
+        ),
+    ]

--- a/txlege84/bills/models.py
+++ b/txlege84/bills/models.py
@@ -128,7 +128,11 @@ class Sponsorship(models.Model):
     legislator = models.ForeignKey(Legislator, related_name='sponsorships')
     bill = models.ForeignKey(Bill, related_name='sponsorships')
     role = models.CharField(max_length=20)
+    ordering = models.PositiveIntegerField(default=0)
 
     def __unicode__(self):
         return u'{0} as {1} of {2}'.format(
             self.legislator.full_name, self.role, self.bill)
+
+    class Meta:
+        ordering = ['ordering']


### PR DESCRIPTION
Finally nailing this issue with ordering of authors by adding an explicit `ordering` field to `Sponsorship`. One more `loadbills` and everyone should be in the right place.
